### PR TITLE
Implement RFC 0050: Partial Rename Buildpacks

### DIFF
--- a/smoke/java_native_image_test.go
+++ b/smoke/java_native_image_test.go
@@ -74,9 +74,9 @@ func testJavaNativeImage(t *testing.T, context spec.G, it spec.S) {
 			Eventually(container).Should(BeAvailable())
 
 			Expect(logs).To(ContainLines(ContainSubstring("Paketo BellSoft Liberica Buildpack")))
-			Expect(logs).To(ContainLines(ContainSubstring("Paketo Maven Buildpack")))
-			Expect(logs).To(ContainLines(ContainSubstring("Paketo Executable JAR Buildpack")))
-			Expect(logs).To(ContainLines(ContainSubstring("Paketo Spring Boot Buildpack")))
+			Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Maven")))
+			Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Executable JAR")))
+			Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Spring Boot")))
 			Expect(logs).To(ContainLines(ContainSubstring("Paketo Native Image Buildpack")))
 		})
 	})

--- a/smoke/java_test.go
+++ b/smoke/java_test.go
@@ -71,9 +71,9 @@ func testJava(t *testing.T, context spec.G, it spec.S) {
 			Eventually(container).Should(BeAvailable())
 
 			Expect(logs).To(ContainLines(ContainSubstring("Paketo BellSoft Liberica Buildpack")))
-			Expect(logs).To(ContainLines(ContainSubstring("Paketo Maven Buildpack")))
-			Expect(logs).To(ContainLines(ContainSubstring("Paketo Executable JAR Buildpack")))
-			Expect(logs).To(ContainLines(ContainSubstring("Paketo Spring Boot Buildpack")))
+			Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Maven")))
+			Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Executable JAR")))
+			Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Spring Boot")))
 		})
 	})
 }


### PR DESCRIPTION
## Summary
    Partially renames 'Paketo <tech> Buildpack' to 'Paketo Buildpack for <tech>' where present in README or Go code.

    Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this project.

    This is done for a subset of buildpacks:

    - spring-boot
    - appdynamics
    - datadog
    - jprofiler
    - google-stackdriver
    - adoptium
    - sbt
    - maven
    - gradle
    - syft
    - executable-jar

## Use Cases

    This should unblock the builders until the rest of the buildpacks can be released under the new name.


## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
