### PR TITLE
Replacing gcr with docker registry for the buildpacks that participate

### DIFF
--- a/builder.toml
+++ b/builder.toml
@@ -1,19 +1,19 @@
 description = "Tiny base image (Ubuntu Jammy Jellyfish build image, distroless-like run image) with buildpacks for Java, Java Native Image and Go"
 
 [[buildpacks]]
-  uri = "docker://gcr.io/paketo-buildpacks/go:4.15.0"
+  uri = "docker://docker.io/paketobuildpacks/go:4.15.0"
   version = "4.15.0"
 
 [[buildpacks]]
-  uri = "docker://gcr.io/paketo-buildpacks/java-native-image:11.9.0"
+  uri = "docker://docker.io/paketobuildpacks/java-native-image:11.9.0"
   version = "11.9.0"
 
 [[buildpacks]]
-  uri = "docker://gcr.io/paketo-buildpacks/java:18.5.0"
+  uri = "docker://docker.io/paketobuildpacks/java:18.5.0"
   version = "18.5.0"
 
 [[buildpacks]]
-  uri = "docker://gcr.io/paketo-buildpacks/procfile:5.11.0"
+  uri = "docker://docker.io/paketobuildpacks/procfile:5.11.0"
   version = "5.11.0"
 
 [lifecycle]

--- a/smoke/testdata/go/README.md
+++ b/smoke/testdata/go/README.md
@@ -2,7 +2,7 @@
 
 ## Building
 
-`pack build mod-sample --buildpack gcr.io/paketo-buildpacks/go`
+`pack build mod-sample --buildpack docker.io/paketobuildpacks/go`
 
 ## Running
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR alters the registry that the buildpacks are getting pulled from, from GCR to Docker.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
